### PR TITLE
DOCSP-48751: Disallow comma in authMechanismProperties

### DIFF
--- a/source/includes/security/auth-properties-commas.rst
+++ b/source/includes/security/auth-properties-commas.rst
@@ -1,6 +1,6 @@
 .. important::
 
    You cannot pass values containing the comma (``,``) character to the ``authMechanismProperties`` 
-   connection string option. To specify a value that contains a comma, use the
-   `mongoc_uri_set_mechanism_properties() <{+api-libmongoc+}mongoc_uri_set_mechanism_properties.html>`__
-   method to set the ``authMechanismProperties`` option.
+   connection string option. To specify a ``authMechanismProperties`` value that contains a comma,
+   set the option by using the `mongoc_uri_set_mechanism_properties()
+   <{+api-libmongoc+}/mongoc_uri_set_mechanism_properties.html>`__ method.

--- a/source/includes/security/auth-properties-commas.rst
+++ b/source/includes/security/auth-properties-commas.rst
@@ -1,0 +1,6 @@
+.. important::
+
+   You cannot pass values containing the comma (``,``) character to the ``authMechanismProperties`` 
+   connection string option. To specify a value that contains a comma, use the
+   `mongoc_uri_set_mechanism_properties() <{+api-libmongoc+}mongoc_uri_set_mechanism_properties.html>`__
+   method to set the ``authMechanismProperties`` option.

--- a/source/includes/security/auth-properties-commas.rst
+++ b/source/includes/security/auth-properties-commas.rst
@@ -1,6 +1,6 @@
 .. important::
 
    You cannot pass values containing the comma (``,``) character to the ``authMechanismProperties`` 
-   connection string option. To specify a ``authMechanismProperties`` value that contains a comma,
+   connection string option. To specify an ``authMechanismProperties`` value that contains a comma,
    set the option by using the `mongoc_uri_set_mechanism_properties()
    <{+api-libmongoc+}/mongoc_uri_set_mechanism_properties.html>`__ method.

--- a/source/includes/security/auth-properties-commas.rst
+++ b/source/includes/security/auth-properties-commas.rst
@@ -1,6 +1,8 @@
 .. important::
 
-   You cannot pass values containing the comma (``,``) character to the ``authMechanismProperties`` 
-   connection string option. To specify an ``authMechanismProperties`` value that contains a comma,
-   set the option by using the `mongoc_uri_set_mechanism_properties()
-   <{+api-libmongoc+}/mongoc_uri_set_mechanism_properties.html>`__ method.
+   You cannot specify a property value containing the comma (``,``) character
+   as a ``authMechanismProperties`` connection string option, even when the 
+   comma character is percent-encoded. To specify an ``authMechanismProperties``
+   property value that contains a comma, set the option by using the
+   `mongoc_uri_set_mechanism_properties() <{+api-libmongoc+}/mongoc_uri_set_mechanism_properties.html>`__
+   method.

--- a/source/security/authentication.txt
+++ b/source/security/authentication.txt
@@ -168,6 +168,8 @@ You can also include an AWS session token by passing it into the
    :start-after: // start-aws-connection-uri-session
    :end-before: // end-aws-connection-uri-session
 
+.. include:: /includes/security/auth-properties-commas.rst
+
 .. _c-mongo-aws-environment:
 
 Environment Variables

--- a/source/security/enterprise-authentication.txt
+++ b/source/security/enterprise-authentication.txt
@@ -92,6 +92,8 @@ Complete the following steps to authenticate with GSSAPI:
          You must replace the ``@`` symbol in the principal with ``%40``, as shown
          in the preceding example.
 
+.. include:: /includes/security/auth-properties-commas.rst
+
 .. _c-plain:
 
 PLAIN SASL

--- a/source/security/enterprise-authentication.txt
+++ b/source/security/enterprise-authentication.txt
@@ -92,7 +92,7 @@ Complete the following steps to authenticate with GSSAPI:
          You must replace the ``@`` symbol in the principal with ``%40``, as shown
          in the preceding example.
 
-.. include:: /includes/security/auth-properties-commas.rst
+      .. include:: /includes/security/auth-properties-commas.rst
 
 .. _c-plain:
 


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-golang/blob/master/REVIEWING.md)

JIRA - https://jira.mongodb.org/browse/DOCSP-48751

### Staging Links

<!-- start insert-links -->
<li><a href=https://deploy-preview-106--docs-c.netlify.app/security/authentication>security/authentication</a></li><li><a href=https://deploy-preview-106--docs-c.netlify.app/security/enterprise-authentication>security/enterprise-authentication</a></li>
<!-- end insert-links -->

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [ ] Are all the links working?
- [ ] Are the [facets and meta keywords](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) accurate?
