### PR TITLE
Add missing meta descriptions

### DIFF
--- a/source/index.txt
+++ b/source/index.txt
@@ -2,6 +2,9 @@
 {+driver-long+}
 ================
 
+.. meta::
+   :description: Explore resources for using the MongoDB C Driver, including installation, connection setup, data operations, and more.
+
 .. toctree::
    :titlesonly:
    :maxdepth: 1


### PR DESCRIPTION
Adds missing meta descriptions generated by the Education AI Team\n\nSOURCE: https://docs.google.com/spreadsheets/d/1fdrjF4Ms9fMl96zLiLGsYD_V38rTfPLuKs5VQk4vz6E/edit?gid=1166644539