### PR TITLE
DOCSP-49133 Fix Old Connect to MongoDB Redirect

### DIFF
--- a/config/redirects
+++ b/config/redirects
@@ -66,4 +66,9 @@ raw: ${prefix}/current/libbson -> ${base}/current/
 (v1.28-master]: ${prefix}/${version}/libmongoc/guides/aggregate/ -> ${base}/${version}/aggregation/
 (v1.28-master]: ${prefix}/${version}/libmongoc/guides/advanced-connections/ -> ${base}/${version}/read-write-configuration/
 
-
+# Get Started Consolidation
+(v1.28-master]: ${prefix}/${version}/get-started/download-and-install/ -> ${base}/${version}/get-started/
+(v1.28-master]: ${prefix}/${version}/get-started/create-a-deployment/ -> ${base}/${version}/get-started/
+(v1.28-master]: ${prefix}/${version}/get-started/create-a-connection-string/ -> ${base}/${version}/get-started/
+(v1.28-master]: ${prefix}/${version}/get-started/connect-to-mongodb/ -> ${base}/${version}/get-started/
+(v1.28-master]: ${prefix}/${version}/get-started/next-steps/ -> ${base}/${version}/get-started/


### PR DESCRIPTION
# Pull Request Info
Added redirects for all the old Getting Started pages. 

[PR Reviewing Guidelines](https://github.com/mongodb/docs-golang/blob/master/REVIEWING.md)

JIRA - <https://jira.mongodb.org/browse/DOCSP-49133>

### Staging Links

<!-- start insert-links -->
No pages to preview
<!-- end insert-links -->

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [x] Are all the links working?
- [ ] Are the [facets and meta keywords](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) accurate?
- [ ] Are the page titles greater than 20 characters long and [SEO relevant](https://docs.google.com/spreadsheets/d/1Wkt0-5z04KmcMNscN5bjUKnzwWAtMq9VESp-Lz6r2o8/edit?usp=sharing)?
